### PR TITLE
chore: drop tiny-invariant

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
   "dependencies": {
     "@babel/helper-module-imports": "^7.16.0",
     "@babel/helper-plugin-utils": "^7.16.7",
-    "@babel/plugin-syntax-jsx": "^7.16.7",
-    "tiny-invariant": "^1.2.0"
+    "@babel/plugin-syntax-jsx": "^7.16.7"
   },
   "peerDependencies": {
     "three": ">=0.126",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { addNamed } from "@babel/helper-module-imports";
 import { declare } from "@babel/helper-plugin-utils";
 import { PluginObj, PluginPass } from "@babel/core";
+import PluginSyntaxJSX from "@babel/plugin-syntax-jsx";
 import assert from "assert";
 
 export default declare<

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,13 @@
 import { addNamed } from "@babel/helper-module-imports";
 import { declare } from "@babel/helper-plugin-utils";
 import { PluginObj, PluginPass } from "@babel/core";
-import PluginSyntaxJSX from "@babel/plugin-syntax-jsx";
-import invariant from "tiny-invariant";
+import assert from "assert";
 
 export default declare<
   { importSources?: string[] },
   PluginObj<PluginPass & { imports?: Set<`${string},${string}`> }>
 >(({ types: t }, { importSources = ["three"] }) => {
-  invariant(Array.isArray(importSources), "importSources must be an array");
+  assert(Array.isArray(importSources), "importSources must be an array");
 
   const NS = importSources.map((id) => require(id));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2645,11 +2645,6 @@ tiny-inflate@^1.0.3:
   resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.3.tgz#122715494913a1805166aaf7c93467933eea26c4"
   integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
 
-tiny-invariant@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
-  integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
-
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"


### PR DESCRIPTION
- Reduces dependencies. Even though tiny-invariant is [pretty small](https://packagephobia.com/result?p=tiny-invariant), the built-in `assert` is already shipped in Node.js. 
- [Resolves](https://twitter.com/umariomaker/status/1509518634154180616?s=20&t=YTAqO_2bxP5_2rSIrs09Cw)