### PR TITLE
fix: wrap extend call expression in statement so it's closed with a semicolon

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export default declare<
             t.objectProperty(t.identifier(name), importNames[i], false, true)
           );
           const objectExpression = t.objectExpression(objectProperties);
-          const extendCall = t.callExpression(extendName, [objectExpression]);
+          const extendCall = t.expressionStatement(t.callExpression(extendName, [objectExpression]));
           const body = path.get("body");
           if (Array.isArray(body)) {
             const lastImport = body

--- a/tests/__snapshots__/plugin.test.ts.snap
+++ b/tests/__snapshots__/plugin.test.ts.snap
@@ -13,7 +13,7 @@ _extend({
   Mesh: _Mesh,
   BoxGeometry: _BoxGeometry,
   MeshStandardMaterial: _MeshStandardMaterial
-})
+});
 
 createRoot(canvasNode).render(<>
     <orbitControls />
@@ -35,7 +35,7 @@ _extend({
   Mesh: _Mesh,
   BoxGeometry: _BoxGeometry,
   MeshStandardMaterial: _MeshStandardMaterial
-})
+});
 
 createRoot(canvasNode).render(<mesh>
     <boxGeometry />
@@ -54,7 +54,7 @@ _extend({
   Mesh: _Mesh,
   BoxGeometry: _BoxGeometry,
   MeshStandardMaterial: _MeshStandardMaterial
-})
+});
 
 createRoot(canvasNode).render(<mesh>
     <boxGeometry />
@@ -75,7 +75,7 @@ _extend({
   Mesh: _Mesh,
   BoxGeometry: _BoxGeometry,
   MeshPhongMaterial: _MeshPhongMaterial
-})
+});
 
 function Box(props) {
   const [active, setActive] = useState(false);
@@ -105,7 +105,7 @@ _extend({
   Mesh: _Mesh,
   BoxGeometry: _BoxGeometry,
   MeshStandardMaterial: _MeshStandardMaterial
-})
+});
 
 createRoot(canvasNode).render(<mesh>
     <boxGeometry />
@@ -128,7 +128,7 @@ _extend({
   Mesh: _Mesh,
   BoxGeometry: _BoxGeometry,
   MeshStandardMaterial: _MeshStandardMaterial
-})
+});
 
 createRoot(canvasNode).render(<mesh>
     <boxGeometry />


### PR DESCRIPTION
This solves the `Module parse failed: Unexpected token` error when building a minified bundle. The call expression is inserted as-is, and expressions don't get a semicolon by design.

Closes #8